### PR TITLE
Allow AMQP extensions to be passed when connecting to RMQ broker.

### DIFF
--- a/Modules/_librabbitmq/connection.h
+++ b/Modules/_librabbitmq/connection.h
@@ -165,7 +165,7 @@ static PyObject*
 PyRabbitMQ_Connection_fileno(PyRabbitMQ_Connection *);
 
 static PyObject*
-PyRabbitMQ_Connection_connect(PyRabbitMQ_Connection *);
+PyRabbitMQ_Connection_connect(PyRabbitMQ_Connection *, PyObject *);
 
 static PyObject*
 PyRabbitMQ_Connection_close(PyRabbitMQ_Connection *);
@@ -263,7 +263,7 @@ static PyMethodDef PyRabbitMQ_ConnectionType_methods[] = {
     {"fileno", (PyCFunction)PyRabbitMQ_Connection_fileno,
         METH_NOARGS, "File descriptor number."},
     {"connect", (PyCFunction)PyRabbitMQ_Connection_connect,
-        METH_NOARGS, "Establish connection to the broker."},
+        METH_VARARGS, "Establish connection to the broker."},
     {"_close", (PyCFunction)PyRabbitMQ_Connection_close,
         METH_NOARGS, "Close connection."},
     {"_channel_open", (PyCFunction)PyRabbitMQ_Connection_channel_open,

--- a/librabbitmq/__init__.py
+++ b/librabbitmq/__init__.py
@@ -173,9 +173,14 @@ class Connection(_librabbitmq.Connection):
 
     def __init__(self, host='localhost', userid='guest', password='guest',
             virtual_host='/', port=5672, channel_max=0xffff,
-            frame_max=131072, heartbeat=0, lazy=False, **kwargs):
+            frame_max=131072, heartbeat=0, lazy=False, capabilities=None, **kwargs):
         if ':' in host:
             host, port = host.split(':')
+
+        client_properties = None
+        if capabilities:
+            client_properties = {'capabilities': capabilities}
+
         super(Connection, self).__init__(hostname=host, port=int(port),
                                          userid=userid, password=password,
                                          virtual_host=virtual_host,
@@ -185,7 +190,7 @@ class Connection(_librabbitmq.Connection):
         self.channels = {}
         self._avail_channel_ids = array('H', xrange(self.channel_max, 0, -1))
         if not lazy:
-            self.connect()
+            self.connect(client_properties)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
The Kombu library should be modified to support the extensions (https://www.rabbitmq.com/extensions.html).  For now, the librabbitmq extension can be invoked as follows:

```
conn = Connection(host="host", userid="user",
                  password="password", virtual_host="vhost",
                  capabilities={'authentication_failure_close': True})

conn.connect()
```

PR's https://github.com/celery/librabbitmq/pull/45 and https://github.com/celery/librabbitmq/pull/44 are commits that are also part of this PR but can be merged separately.
