### PR TITLE
Fix issues with hostname corruption when Python strings go out of scope.

### DIFF
--- a/Modules/_librabbitmq/connection.c
+++ b/Modules/_librabbitmq/connection.c
@@ -908,6 +908,19 @@ PyRabbitMQ_ConnectionType_dealloc(PyRabbitMQ_Connection *self)
 {
     if (self->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject*)self);
+
+    if (self->hostname != NULL)
+      PyMem_Free(self->hostname);
+
+    if (self->userid != NULL)
+      PyMem_Free(self->userid);
+
+    if (self->password != NULL)
+      PyMem_Free(self->password);
+
+    if (self->virtual_host != NULL)
+      PyMem_Free(self->virtual_host);
+
     Py_XDECREF(self->callbacks);
     Py_XDECREF(self->server_properties);
     self->ob_type->tp_free(self);
@@ -932,10 +945,11 @@ PyRabbitMQ_ConnectionType_init(PyRabbitMQ_Connection *self,
         "heartbeat",
         NULL
     };
-    char *hostname = "localhost";
-    char *userid = "guest";
-    char *password = "guest";
-    char *virtual_host = "/";
+    char *hostname;
+    char *userid;
+    char *password;
+    char *virtual_host;
+
     int channel_max = 0xffff;
     int frame_max = 131072;
     int heartbeat = 0;
@@ -947,10 +961,20 @@ PyRabbitMQ_ConnectionType_init(PyRabbitMQ_Connection *self,
         return -1;
     }
 
-    self->hostname = hostname;
-    self->userid = userid;
-    self->password = password;
-    self->virtual_host = virtual_host;
+    self->hostname = PyMem_Malloc(strlen(hostname) + 1);
+    self->userid = PyMem_Malloc(strlen(userid) + 1);
+    self->password = PyMem_Malloc(strlen(password) + 1);
+    self->virtual_host = PyMem_Malloc(strlen(virtual_host) + 1);
+
+    if (self->hostname == NULL || self->userid == NULL || self->password == NULL || self->virtual_host == NULL) {
+        return PyErr_NoMemory();
+    }
+
+    strcpy(self->hostname, hostname);
+    strcpy(self->userid, userid);
+    strcpy(self->password, password);
+    strcpy(self->virtual_host, virtual_host);
+
     self->port = port;
     self->channel_max = channel_max;
     self->frame_max = frame_max;


### PR DESCRIPTION
We store references to hostname, userid, virtual_host, and password inside a RabbitMQ state object. However, once those arguments leave scope inside the __init__() function, Python deallocates the memory.

If we want to keep references to them, we need to do custom malloc operations to store them and deallocate them when we're no longer using the object.

I noticed this problem when putting a breakpoint on the kombu/transport/librabbitmq.py establish_connection() and attempted to print the Connection object.  On multiple publishing, I noticed the Connection string object corrupted, particularly the hostname.

Also, string pointers shouldn't have strings defined by default should they?