### PR TITLE
RabbitMQ extensions support

### DIFF
--- a/Modules/_librabbitmq/connection.c
+++ b/Modules/_librabbitmq/connection.c
@@ -292,8 +292,10 @@ PyDict_ToAMQTable(amqp_connection_state_t conn, PyObject *src, amqp_pool_t *pool
         else if (PyLong_Check(dvalue) || PyInt_Check(dvalue)) {
             /* Int | Long */
             clong_value = (int64_t)PyLong_AsLong(dvalue);
-            if (PyErr_Occurred())
-                goto error;
+
+            if (clong_value == -1)
+              goto error;
+
             AMQTable_SetIntValue(&dst,
                     PyString_AS_AMQBYTES(dkey),
                     clong_value
@@ -301,8 +303,10 @@ PyDict_ToAMQTable(amqp_connection_state_t conn, PyObject *src, amqp_pool_t *pool
         }
         else if (PyFloat_Check(dvalue)) {
             cdouble_value = PyFloat_AsDouble(dvalue);
-            if (PyErr_Occurred())
-                goto error;
+
+            if (cdouble_value == -1)
+              goto error;
+
             AMQTable_SetDoubleValue(&dst,
                 PyString_AS_AMQBYTES(dkey),
                     cdouble_value

--- a/Modules/_librabbitmq/connection.c
+++ b/Modules/_librabbitmq/connection.c
@@ -936,6 +936,7 @@ PyRabbitMQ_ConnectionType_dealloc(PyRabbitMQ_Connection *self)
     if (self->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject*)self);
     Py_XDECREF(self->callbacks);
+    Py_XDECREF(self->client_properties);
     Py_XDECREF(self->server_properties);
     self->ob_type->tp_free(self);
 }
@@ -957,6 +958,7 @@ PyRabbitMQ_ConnectionType_init(PyRabbitMQ_Connection *self,
         "channel_max",
         "frame_max",
         "heartbeat",
+        "client_properties",
         NULL
     };
     char *hostname = "localhost";
@@ -967,10 +969,11 @@ PyRabbitMQ_ConnectionType_init(PyRabbitMQ_Connection *self,
     int frame_max = 131072;
     int heartbeat = 0;
     int port = 5672;
+    PyObject *client_properties = NULL;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ssssiiii", kwlist,
-                &hostname, &userid, &password, &virtual_host, &port,
-                &channel_max, &frame_max, &heartbeat)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ssssiiiiO", kwlist,
+                                     &hostname, &userid, &password, &virtual_host, &port,
+                                     &channel_max, &frame_max, &heartbeat, &client_properties)) {
         return -1;
     }
 
@@ -985,8 +988,10 @@ PyRabbitMQ_ConnectionType_init(PyRabbitMQ_Connection *self,
     self->weakreflist = NULL;
     self->callbacks = PyDict_New();
     if (self->callbacks == NULL) return -1;
-    self->server_properties = NULL;
 
+    Py_XINCREF(client_properties);
+    self->client_properties = client_properties;
+    self->server_properties = NULL;
     return 0;
 }
 
@@ -1016,6 +1021,8 @@ PyRabbitMQ_Connection_connect(PyRabbitMQ_Connection *self)
     int status;
     amqp_socket_t *socket = NULL;
     amqp_rpc_reply_t reply;
+    amqp_pool_t pool;
+    amqp_table_t properties;
 
     if (self->connected) {
         PyErr_SetString(PyRabbitMQExc_ConnectionError, "Already connected");
@@ -1039,12 +1046,25 @@ PyRabbitMQ_Connection_connect(PyRabbitMQ_Connection *self)
 
     Py_BEGIN_ALLOW_THREADS;
     self->sockfd = amqp_socket_get_sockfd(socket);
-    reply = amqp_login(self->conn, self->virtual_host, self->channel_max,
-                       self->frame_max, self->heartbeat,
-                       AMQP_SASL_METHOD_PLAIN, self->userid, self->password);
+
+    if (self->client_properties != NULL && PyDict_Check(self->client_properties)) {
+      init_amqp_pool(&pool, self->frame_max);
+      properties = PyDict_ToAMQTable(self->conn, self->client_properties, &pool);
+
+      reply = amqp_login_with_properties(self->conn, self->virtual_host, self->channel_max,
+                                         self->frame_max, self->heartbeat,
+                                         &properties,
+                                         AMQP_SASL_METHOD_PLAIN, self->userid, self->password);
+    } else {
+      reply = amqp_login(self->conn, self->virtual_host, self->channel_max,
+                         self->frame_max, self->heartbeat,
+                         AMQP_SASL_METHOD_PLAIN, self->userid, self->password);
+    }
+
     Py_END_ALLOW_THREADS;
+
     if (PyRabbitMQ_HandleAMQError(self, 0, reply, "Couldn't log in"))
-        goto bail;
+      goto bail;
 
     /* after tune */
     self->connected = 1;

--- a/Modules/_librabbitmq/connection.c
+++ b/Modules/_librabbitmq/connection.c
@@ -39,6 +39,9 @@ _PYRMQ_INLINE void
 AMQTable_SetStringValue(amqp_table_t*, amqp_bytes_t, amqp_bytes_t);
 
 _PYRMQ_INLINE void
+AMQTable_SetBoolValue(amqp_table_t*, amqp_bytes_t, int);
+
+_PYRMQ_INLINE void
 AMQTable_SetIntValue(amqp_table_t *, amqp_bytes_t, int);
 
 _PYRMQ_INLINE void
@@ -161,6 +164,15 @@ AMQTable_SetStringValue(amqp_table_t *table,
 }
 
 _PYRMQ_INLINE void
+AMQTable_SetBoolValue(amqp_table_t *table,
+                      amqp_bytes_t key, int value)
+{
+    amqp_table_entry_t *entry = AMQTable_AddEntry(table, key);
+    entry->value.kind = AMQP_FIELD_KIND_BOOLEAN;
+    entry->value.value.boolean = value;
+}
+
+_PYRMQ_INLINE void
 AMQTable_SetIntValue(amqp_table_t *table,
                      amqp_bytes_t key, int value)
 {
@@ -265,6 +277,17 @@ PyDict_ToAMQTable(amqp_connection_state_t conn, PyObject *src, amqp_pool_t *pool
             AMQTable_SetArrayValue(&dst,
                     PyString_AS_AMQBYTES(dkey),
                     PyIter_ToAMQArray(conn, dvalue, pool));
+        }
+        else if (PyBool_Check(dvalue)) {
+          /* Bool */
+          clong_value = 0;  /* default false */
+
+          if (dvalue == Py_True)
+            clong_value = 1;
+
+          AMQTable_SetBoolValue(&dst,
+                                PyString_AS_AMQBYTES(dkey),
+                                clong_value);
         }
         else if (PyLong_Check(dvalue) || PyInt_Check(dvalue)) {
             /* Int | Long */

--- a/Modules/_librabbitmq/connection.h
+++ b/Modules/_librabbitmq/connection.h
@@ -140,6 +140,7 @@ typedef struct {
     int sockfd;
     int connected;
 
+    PyObject *client_properties;
     PyObject *server_properties;
     PyObject *callbacks;    /* {channel_id: {consumer_tag:callback}} */
 

--- a/librabbitmq/__init__.py
+++ b/librabbitmq/__init__.py
@@ -173,15 +173,17 @@ class Connection(_librabbitmq.Connection):
 
     def __init__(self, host='localhost', userid='guest', password='guest',
             virtual_host='/', port=5672, channel_max=0xffff,
-            frame_max=131072, heartbeat=0, lazy=False, **kwargs):
+            frame_max=131072, heartbeat=0, lazy=False, client_properties=None, **kwargs):
         if ':' in host:
             host, port = host.split(':')
+
         super(Connection, self).__init__(hostname=host, port=int(port),
                                          userid=userid, password=password,
                                          virtual_host=virtual_host,
                                          channel_max=channel_max,
                                          frame_max=frame_max,
-                                         heartbeat=heartbeat)
+                                         heartbeat=heartbeat,
+                                         client_properties=client_properties)
         self.channels = {}
         self._avail_channel_ids = array('H', xrange(self.channel_max, 0, -1))
         if not lazy:


### PR DESCRIPTION
```
from librabbitmq import Connection

conn = Connection(host="host", userid="user",
                  password="password", virtual_host="vhost",
                  client_properties={'capabilities': {'authentication_failure_close': True}})

conn.connect()
```

PR's https://github.com/celery/librabbitmq/pull/45 and https://github.com/celery/librabbitmq/pull/44 are commits that are also part of this PR but can be merged separately.

Previous implementation (https://github.com/celery/librabbitmq/pull/46) works fine but now we expose client_properties as the API instead of capabilities and also enable support within the librabbitmq Python __init__.py file.  

This current approach also allows the connection parameters to be initialized as Kombu Connection objects too.