### PR TITLE
Update to correct submodule URL for rabbitmq-codegen.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "rabbitmq-codegen"]
 	path = rabbitmq-codegen
-	url = https://github.com/rabbitmq/rabbitmq-codegen/
+	url = https://github.com/rabbitmq/rabbitmq-codegen.git
 [submodule "rabbitmq-c"]
 	path = rabbitmq-c
 	url = https://github.com/ask/rabbitmq-c.git


### PR DESCRIPTION
With trailing slash, this breaks various checkouts which include librabbitmq as a submodule. Without, everything is happy again.