### PR TITLE
Modification to allow for empty message bodies.

### DIFF
--- a/Modules/_librabbitmq/connection.c
+++ b/Modules/_librabbitmq/connection.c
@@ -1340,7 +1340,11 @@ PyRabbitMQ_recv(PyRabbitMQ_Connection *self, PyObject *p,
                  *buf++ = *bufp++, j++);
         }
         if (p) {
-            if (!payload) goto error;
+            if (body_target && !payload) //We expected content, got none
+                goto error;
+            else if (!payload) //We expected no content, return emptystring
+                payload = PyString_FromStringAndSize(NULL, 0);
+            
             PyDict_SetItemString(p, "properties", propdict);
             PyDict_SetItemString(p, "body", payload);
             PyDict_SetItemString(p, "channel", channel);


### PR DESCRIPTION
If we receive a message with no body (and no body_target length), we
should accept the fact and return an empty body rather than throwing
an exception about the frame.

This is a fix (hopefully) for both #30 and #48.

And I waffled on handling the final case, of receiving a payload with a declared zero length and a non-zero length body , but I don't think the logic further up will ever do that, so left it out of the patch for simplicity.
