### PR TITLE
Update setup.py to fix buildout-related problems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,13 @@ if 'install' in sys.argv and 'build' not in sys.argv:
     sys.argv[:] = (
         sys.argv[:_index] + ['build', 'install'] + sys.argv[_index + 1:]
     )
-
+    
+# 'bdist_egg doesn't always call build for some reason
+if 'bdist_egg' in sys.argv and 'build' not in sys.argv:
+    _index = sys.argv.index('bdist_egg')
+    sys.argv[:] = (
+        sys.argv[:_index] + ['build', 'bdist_egg'] + sys.argv[_index + 1:]
+    )
 
 setup(
     name='librabbitmq',


### PR DESCRIPTION
There're some issues related to Buildout having troubles installing librabbitmq: https://github.com/celery/librabbitmq/issues/61, https://github.com/celery/librabbitmq/issues/58
It seems that this simple change fixes it. Not the prettiest solution, but it works.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/celery/librabbitmq/62)
<!-- Reviewable:end -->
