### PR TITLE
Initial attempt at python3 support

### DIFF
--- a/Modules/_librabbitmq/connection.c
+++ b/Modules/_librabbitmq/connection.c
@@ -266,7 +266,7 @@ PyDict_ToAMQTable(amqp_connection_state_t conn, PyObject *src, amqp_pool_t *pool
                     PyString_AS_AMQBYTES(dkey),
                     PyIter_ToAMQArray(conn, dvalue, pool));
         }
-        else if (PyLong_Check(dvalue) || PyInt_Check(dvalue)) {
+        else if (PyLong_Check(dvalue)) {
             /* Int | Long */
             clong_value = (int64_t)PyLong_AsLong(dvalue);
             if (PyErr_Occurred())
@@ -288,7 +288,7 @@ PyDict_ToAMQTable(amqp_connection_state_t conn, PyObject *src, amqp_pool_t *pool
         else {
             /* String | Unicode */
             is_unicode = PyUnicode_Check(dvalue);
-            if (is_unicode || PyString_Check(dvalue)) {
+            if (is_unicode) {
                 if (is_unicode) {
                     if ((dvalue = PyUnicode_AsASCIIString(dvalue)) == NULL)
                         goto error;
@@ -300,9 +300,7 @@ PyDict_ToAMQTable(amqp_connection_state_t conn, PyObject *src, amqp_pool_t *pool
             }
             else {
                 /* unsupported type */
-                PyErr_Format(PyExc_ValueError,
-                    "Table member %s is of an unsupported type",
-                    PyString_AS_STRING(dkey));
+                PyErr_Format(PyExc_ValueError, "Table member %s is of an unsupported type", dkey);
                 goto error;
             }
         }
@@ -347,7 +345,7 @@ PyIter_ToAMQArray(amqp_connection_state_t conn, PyObject *src, amqp_pool_t *pool
             AMQArray_SetArrayValue(
                 &dst, PyIter_ToAMQArray(conn, item, pool));
         }
-        else if (PyLong_Check(item) || PyInt_Check(item)) {
+        else if (PyLong_Check(item)) {
             /* Int | Long */
             clong_value = (int64_t)PyLong_AsLong(item);
             AMQArray_SetIntValue(&dst, clong_value);
@@ -355,11 +353,9 @@ PyIter_ToAMQArray(amqp_connection_state_t conn, PyObject *src, amqp_pool_t *pool
         else {
             /* String | Unicode */
             is_unicode = PyUnicode_Check(item);
-            if (is_unicode || PyString_Check(item)) {
-                if (is_unicode) {
-                    if ((item = PyUnicode_AsASCIIString(item)) == NULL)
-                        goto item_error;
-                }
+            if (is_unicode) {
+                if ((item = PyUnicode_AsASCIIString(item)) == NULL)
+                    goto item_error;
                 AMQArray_SetStringValue(
                     &dst, PyString_AS_AMQBYTES(item));
             }
@@ -481,15 +477,15 @@ basic_properties_to_PyDict(amqp_basic_properties_t *props, PyObject *p)
         PyDICT_SETSTR_DECREF(p, "app_id", value);
     }
     if (props->_flags & AMQP_BASIC_DELIVERY_MODE_FLAG) {
-        value = PyInt_FromLong(props->delivery_mode);
+        value = PyLong_FromLong(props->delivery_mode);
         PyDICT_SETSTR_DECREF(p, "delivery_mode", value);
     }
     if (props->_flags & AMQP_BASIC_PRIORITY_FLAG) {
-        value =PyInt_FromLong(props->priority);
+        value =PyLong_FromLong(props->priority);
         PyDICT_SETSTR_DECREF(p, "priority", value);
     }
     if (props->_flags & AMQP_BASIC_TIMESTAMP_FLAG) {
-        value = PyInt_FromLong(props->timestamp);
+        value = PyLong_FromLong(props->timestamp);
         PyDICT_SETSTR_DECREF(p, "timestamp", value);
     }
     if (props->_flags & AMQP_BASIC_HEADERS_FLAG) {
@@ -518,13 +514,13 @@ AMQTable_toPyDict(amqp_table_t *table)
                     value = PyBool_FromLong(AMQTable_VAL(table, i, boolean));
                     break;
                 case AMQP_FIELD_KIND_I8:
-                    value = PyInt_FromLong(AMQTable_VAL(table, i, i8));
+                    value = PyLong_FromLong(AMQTable_VAL(table, i, i8));
                     break;
                 case AMQP_FIELD_KIND_I16:
-                    value = PyInt_FromLong(AMQTable_VAL(table, i, i16));
+                    value = PyLong_FromLong(AMQTable_VAL(table, i, i16));
                     break;
                 case AMQP_FIELD_KIND_I32:
-                    value = PyInt_FromLong(AMQTable_VAL(table, i, i32));
+                    value = PyLong_FromLong(AMQTable_VAL(table, i, i32));
                     break;
                 case AMQP_FIELD_KIND_I64:
                     value = PyLong_FromLong(AMQTable_VAL(table, i, i64));
@@ -591,13 +587,13 @@ AMQArray_toPyList(amqp_array_t *array)
                     value = PyBool_FromLong(AMQArray_VAL(array, i, boolean));
                     break;
                 case AMQP_FIELD_KIND_I8:
-                    value = PyInt_FromLong(AMQArray_VAL(array, i, i8));
+                    value = PyLong_FromLong(AMQArray_VAL(array, i, i8));
                     break;
                 case AMQP_FIELD_KIND_I16:
-                    value = PyInt_FromLong(AMQArray_VAL(array, i, i16));
+                    value = PyLong_FromLong(AMQArray_VAL(array, i, i16));
                     break;
                 case AMQP_FIELD_KIND_I32:
-                    value = PyInt_FromLong(AMQArray_VAL(array, i, i32));
+                    value = PyLong_FromLong(AMQArray_VAL(array, i, i32));
                     break;
                 case AMQP_FIELD_KIND_I64:
                     value = PyLong_FromLong(AMQArray_VAL(array, i, i64));
@@ -703,15 +699,15 @@ PyDict_to_basic_properties(PyObject *p,
         props->_flags |= AMQP_BASIC_APP_ID_FLAG;
     }
     if ((value = PyDict_GetItemString(p, "delivery_mode")) != NULL) {
-        props->delivery_mode = (uint8_t)PyInt_AS_LONG(value);
+        props->delivery_mode = (uint8_t)PyLong_AS_LONG(value);
         props->_flags |= AMQP_BASIC_DELIVERY_MODE_FLAG;
     }
     if ((value = PyDict_GetItemString(p, "priority")) != NULL) {
-        props->priority = (uint8_t)PyInt_AS_LONG(value);
+        props->priority = (uint8_t)PyLong_AS_LONG(value);
         props->_flags |= AMQP_BASIC_PRIORITY_FLAG;
     }
     if ((value = PyDict_GetItemString(p, "timestamp")) != NULL) {
-        props->timestamp = (uint8_t)PyInt_AS_LONG(value);
+        props->timestamp = (uint8_t)PyLong_AS_LONG(value);
         props->_flags |= AMQP_BASIC_TIMESTAMP_FLAG;
     }
 
@@ -910,7 +906,7 @@ PyRabbitMQ_ConnectionType_dealloc(PyRabbitMQ_Connection *self)
         PyObject_ClearWeakRefs((PyObject*)self);
     Py_XDECREF(self->callbacks);
     Py_XDECREF(self->server_properties);
-    self->ob_type->tp_free(self);
+    Py_TYPE(self)->tp_free(self);
 }
 
 
@@ -971,7 +967,7 @@ static PyObject*
 PyRabbitMQ_Connection_fileno(PyRabbitMQ_Connection *self)
 {
     if (self->sockfd > 0) {
-        return PyInt_FromLong((long)self->sockfd);
+        return PyLong_FromLong((long)self->sockfd);
     }
     else {
         PyErr_SetString(PyExc_ValueError, "Socket not connected");
@@ -1165,7 +1161,7 @@ PyRabbitMQ_ApplyCallback(PyRabbitMQ_Connection *self,
         goto error;
 
     /* message = self.Message(channel, properties, delivery_info, body) */
-    Message = PyString_FromString("Message");
+    Message = PyUnicode_FromString("Message");
     message = PyObject_CallMethodObjArgs((PyObject *)self, Message,
                 channelobj, propdict, delivery_info, view, NULL);
     if (!message)
@@ -1288,7 +1284,7 @@ PyRabbitMQ_recv(PyRabbitMQ_Connection *self, PyObject *p,
         }
 
         /* channel */
-        channel = PyInt_FromLong((long)frame.channel);
+        channel = PyLong_FromLong((long)frame.channel);
 
         /* properties */
         props = (amqp_basic_properties_t *)frame.payload.properties.decoded;
@@ -1314,23 +1310,21 @@ PyRabbitMQ_recv(PyRabbitMQ_Connection *self, PyObject *p,
             body_received += frame.payload.body_fragment.len;
             if (!i) {
                 if (body_received < body_target) {
-                    payload = PyString_FromStringAndSize(NULL,
+                    payload = PyBytes_FromStringAndSize(NULL,
                                        (PY_SIZE_TYPE)body_target);
                     if (!payload)
                         goto finally;
-                    buf = PyString_AsString(payload);
+                    buf = PyBytes_AsString(payload);
                     if (!buf)
                         goto finally;
-                    view = PyBuffer_FromObject(payload, 0,
-                                   (PY_SIZE_TYPE)body_target);
+                    view = PyObject_GetBuffer(payload, view, 0);
                 }
                 else {
                     if (p) {
                         payload = PySTRING_FROM_AMQBYTES(
                                     frame.payload.body_fragment);
                     } else {
-                        view = PyBuffer_FromMemory(bufp,
-                                    (PY_SIZE_TYPE)frame.payload.body_fragment.len);
+                        view = PyObject_GetBuffer(bufp, view, 0);
                     }
                     break;
                 }
@@ -1345,7 +1339,7 @@ PyRabbitMQ_recv(PyRabbitMQ_Connection *self, PyObject *p,
                 if (body_target) goto error;
 
                 /* did not expect content, return empty string */
-                payload = PyString_FromStringAndSize(NULL, 0);
+                payload = PyUnicode_FromStringAndSize(NULL, 0);
             }
 
             PyDict_SetItemString(p, "properties", propdict);
@@ -1522,7 +1516,7 @@ PyRabbitMQ_Connection_queue_delete(PyRabbitMQ_Connection *self,
             reply, "queue.delete"))
         goto bail;
 
-    return PyInt_FromLong((long)ok->message_count);
+    return PyLong_FromLong((long)ok->message_count);
 bail:
     return 0;
 }
@@ -1582,10 +1576,10 @@ PyRabbitMQ_Connection_queue_declare(PyRabbitMQ_Connection *self,
         goto bail;
 
     if ((ret = PyTuple_New(3)) == NULL) goto bail;
-    PyTuple_SET_ITEM(ret, 0, PyString_FromStringAndSize(ok->queue.bytes,
+    PyTuple_SET_ITEM(ret, 0, PyBytes_FromStringAndSize(ok->queue.bytes,
                                                         ok->queue.len));
-    PyTuple_SET_ITEM(ret, 1, PyInt_FromLong((long)ok->message_count));
-    PyTuple_SET_ITEM(ret, 2, PyInt_FromLong((long)ok->consumer_count));
+    PyTuple_SET_ITEM(ret, 1, PyLong_FromLong((long)ok->message_count));
+    PyTuple_SET_ITEM(ret, 2, PyLong_FromLong((long)ok->consumer_count));
     return ret;
 bail:
     return 0;
@@ -1623,7 +1617,7 @@ PyRabbitMQ_Connection_queue_purge(PyRabbitMQ_Connection *self,
     if (PyRabbitMQ_HandleAMQError(self, channel, reply, "queue.purge"))
         goto bail;
 
-    return PyInt_FromLong((long)ok->message_count);
+    return PyLong_FromLong((long)ok->message_count);
 bail:
     return 0;
 }
@@ -2167,7 +2161,19 @@ static PyMethodDef PyRabbitMQ_functions[] = {
     {NULL, NULL, 0, NULL}
 };
 
-PyMODINIT_FUNC init_librabbitmq(void)
+static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "_librabbitmq",     /* m_name */
+        "Hand-made wrapper for librabbitmq.",  /* m_doc */
+        -1,                  /* m_size */
+        PyRabbitMQ_functions,    /* m_methods */
+        NULL,                /* m_reload */
+        NULL,                /* m_traverse */
+        NULL,                /* m_clear */
+        NULL,                /* m_free */
+    };
+
+PyMODINIT_FUNC PyInit__librabbitmq(void)
 {
     PyObject *module, *socket_module;
 
@@ -2175,16 +2181,15 @@ PyMODINIT_FUNC init_librabbitmq(void)
         return;
     }
 
-    module = Py_InitModule3("_librabbitmq", PyRabbitMQ_functions,
-            "Hand-made wrapper for librabbitmq.");
+    module = PyModule_Create(&moduledef);
     if (module == NULL) {
-        return;
+        return NULL;
     }
 
     /* Get socket.error */
     socket_module = PyImport_ImportModule("socket");
     if (!socket_module)
-        return;
+        return NULL;
     PyRabbitMQ_socket_timeout = PyObject_GetAttrString(socket_module, "timeout");
     Py_XDECREF(socket_module);
 
@@ -2206,5 +2211,5 @@ PyMODINIT_FUNC init_librabbitmq(void)
             "_librabbitmq.ChannelError", NULL, NULL);
     PyModule_AddObject(module, "ChannelError",
                        (PyObject *)PyRabbitMQExc_ChannelError);
-    return;
+    return module;
 }

--- a/Modules/_librabbitmq/connection.h
+++ b/Modules/_librabbitmq/connection.h
@@ -25,7 +25,7 @@
 #  define FROM_FORMAT PyUnicode_FromFormat
 #  define PyInt_FromLong PyLong_FromLong
 #  define PyInt_FromSsize_t PyLong_FromSsize_t
-#  define PyString_INTERN_FROM_STRING PyString_FromString
+#  define PyString_INTERN_FROM_STRING PyUnicode_FromString
 #else                            /* 2.x */
 #  define FROM_FORMAT PyString_FromFormat
 #  define PyString_INTERN_FROM_STRING PyString_InternFromString
@@ -69,7 +69,7 @@
     } while(0)
 
 #define PySTRING_FROM_AMQBYTES(member)                              \
-        PyString_FromStringAndSize(member.bytes, member.len);       \
+        PyBytes_FromStringAndSize(member.bytes, member.len);       \
 
 #define AMQTable_TO_PYKEY(table, i)                                 \
         PySTRING_FROM_AMQBYTES(table->entries[i].key)
@@ -83,7 +83,7 @@ _PYRMQ_INLINE PyObject* Maybe_Unicode(PyObject *);
 
 #if defined(__C99__) || defined(__GNUC__)
 #  define PyString_AS_AMQBYTES(s)                                   \
-      (amqp_bytes_t){Py_SIZE(s), (void *)PyString_AS_STRING(s)}
+      (amqp_bytes_t){Py_SIZE(s), (void *)PyBytes_AsString(s)}
 #else
 _PYRMQ_INLINE amqp_bytes_t PyString_AS_AMQBYTES(PyObject *);
 _PYRMQ_INLINE amqp_bytes_t
@@ -91,8 +91,8 @@ PyString_AS_AMQBYTES(PyObject *s)
 {
     amqp_bytes_t ret;
     ret.len = Py_SIZE(s);
-    ret.bytes = (void *)PyString_AS_STRING(s);
-    /*{Py_SIZE(s), (void *)PyString_AS_STRING(s)};*/
+    ret.bytes = (void *)PyBytes_AsString(s);
+    /*{Py_SIZE(s), (void *)PyBytes_AsString(s)};*/
     return ret;
 }
 #endif
@@ -336,8 +336,7 @@ static PyTypeObject PyRabbitMQ_ConnectionType = {
     /* tp_getattro       */ 0,
     /* tp_setattro       */ 0,
     /* tp_as_buffer      */ 0,
-    /* tp_flags          */ Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-                            Py_TPFLAGS_HAVE_WEAKREFS,
+    /* tp_flags          */ Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     /* tp_doc            */ PyRabbitMQ_ConnectionType_doc,
     /* tp_traverse       */ 0,
     /* tp_clear          */ 0,

--- a/librabbitmq/__init__.py
+++ b/librabbitmq/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import itertools
 
@@ -43,7 +43,7 @@ class Channel(object):
     def __init__(self, connection, channel_id):
         self.connection = connection
         self.channel_id = channel_id
-        self.next_consumer_tag = itertools.count(1).next
+        self.next_consumer_tag = itertools.count(1).__next__
         self.no_ack_consumers = set()
 
     def __enter__(self):
@@ -194,7 +194,7 @@ class Connection(_librabbitmq.Connection):
             frame_max=frame_max, heartbeat=heartbeat,
         )
         self.channels = {}
-        self._avail_channel_ids = array('H', xrange(self.channel_max, 0, -1))
+        self._avail_channel_ids = array('H', range(self.channel_max, 0, -1))
         if not lazy:
             self.connect()
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def senv(*k__v, **kwargs):
     for k, v in k__v:
         prev = restore[k] = os.environ.get(k)
         os.environ[k] = (prev + sep if prev else '') + str(v)
-    return dict((k, v) for k, v in restore.iteritems() if v is not None)
+    return dict((k, v) for k, v in restore.items() if v is not None)
 
 
 def codegen():
@@ -31,8 +31,8 @@ def codegen():
     restore = senv(('PYTHONPATH', SPECPATH()), sep=':')
     try:
         for command in commands:
-            print('- generating %r' % command[-1])
-            print(' '.join(command))
+            print(('- generating %r' % command[-1]))
+            print((' '.join(command)))
             os.system(' '.join(command))
     finally:
         os.environ.update(restore)
@@ -68,10 +68,10 @@ def create_builder():
     sys.argv[1:] = unprocessed
 
     incdirs.append(LRMQSRC())
-    PyC_files = map(PYCP, [
+    PyC_files = list(map(PYCP, [
         'connection.c',
-    ])
-    librabbit_files = map(LRMQSRC, [
+    ]))
+    librabbit_files = list(map(LRMQSRC, [
         'amqp_api.c',
         'amqp_connection.c',
         'amqp_consumer.c',
@@ -83,7 +83,7 @@ def create_builder():
         'amqp_tcp_socket.c',
         'amqp_timer.c',
         'amqp_url.c',
-    ])
+    ]))
 
     incdirs.append(LRMQDIST())  # for config.h
 
@@ -183,13 +183,13 @@ is_pypy = hasattr(sys, 'pypy_version_info')
 is_py3k = sys.version_info[0] == 3
 is_win = platform.system() == 'Windows'
 is_linux = platform.system() == 'Linux'
-if is_jython or is_pypy or is_py3k or is_win:
+if is_jython or is_pypy or is_win:
     pass
 elif find_make():
     try:
         librabbitmq_ext, build = create_builder()
-    except Exception, exc:
-        print('Could not create builder: %r' % (exc, ))
+    except Exception as exc:
+        print(('Could not create builder: %r' % (exc, )))
         raise
     else:
         goahead = True


### PR DESCRIPTION
I've made an initial attempt at python 3 support.  
- Everything compiles and runs- it just doesn't work.
- There are almost certainly some places where I used `PyBytes` where I should have used `PyUnicode` (and vice versa).
- Perhaps the biggest issue is with the buffer.  It is currently using the [old python2 buffer interface](https://docs.python.org/2/c-api/buffer.html) that does not exist in python3.  I made a feeble attempt to use the new python3 memory buffer but it's almost certainly wrong.  
- I didn't make any effort to retain python2 support- I was just focused on getting this to work in python3. Once this is working I would be more than willing to go back and add the necessary switches so it supports python 2.7 as well.  Great resource [here](http://python3porting.com/cextensions.html) regarding that.
