### PR TITLE
Update setup.py for installation to work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ if is_jython or is_pypy or is_py3k or is_win:
 elif find_make():
     try:
         librabbitmq_ext, build = create_builder()
-    except Exception, exc:
+    except Exception as exc:
         print('Could not create builder: %r' % (exc, ))
         raise
     else:


### PR DESCRIPTION
Comma based syntax error here causes 'python setup.py install' and 'pip install librabbitmq' to fail. I propose it is swapped to the correct 'as' syntax