### PR TITLE
body_size should not be a pointer here.

### DIFF
--- a/Modules/_librabbitmq/connection.c
+++ b/Modules/_librabbitmq/connection.c
@@ -1737,7 +1737,7 @@ PyRabbitMQ_Connection_basic_publish(PyRabbitMQ_Connection *self,
     unsigned int immediate = 0;
 
     char *body_buf = NULL;
-    int *body_size = 0;
+    uint32_t body_size = 0;
 
     int ret = 0;
     amqp_basic_properties_t props;


### PR DESCRIPTION
This was breaking body_size encoding in the content frame on big endian servers in 64 bit. Unfortunately, it seems PyArg_ParseTuple t# will only write to a 32 bit integer, not a 64 bit integer, at least on Python 2.7.10 and the docs show the same for future releases.  PyRabbitMQ_Connection_basic_publish is limited compared to the the AMQP spec which allows for 64-bit body sizes.