### PR TITLE
Added .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+dist: trusty
+sudo: required
+
+install:
+  - pip install -r requirements/test-ci.txt
+
+script:
+  - make test
+
+services:
+  - rabbitmq


### PR DESCRIPTION
This is simple PR adding Travis CI support. Travis CI is simple, just runs CI test suit. Travis configuration is tested and seems to be working. Of course, travis support must be turned on in upstream travis account.