### PR TITLE
Add support for pip install directly from git repo - fix #110

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,11 @@ from setuptools import setup, find_packages
 
 # --with-librabbitmq=<dir>: path to librabbitmq package if needed
 
-LRMQDIST = lambda *x: os.path.join('rabbitmq-c', *x)
+BASE_PATH = os.path.dirname(__file__)
+
+LRMQDIST = lambda *x: os.path.join(BASE_PATH, 'rabbitmq-c', *x)
 LRMQSRC = lambda *x: LRMQDIST('librabbitmq', *x)
-PYCP = lambda *x: os.path.join('Modules', '_librabbitmq', *x)
+PYCP = lambda *x: os.path.join(BASE_PATH, 'Modules', '_librabbitmq', *x)
 
 
 def senv(*k__v, **kwargs):
@@ -162,7 +164,7 @@ def find_make(alt=('gmake', 'gnumake', 'make', 'nmake')):
                 return make
 
 
-long_description = open('README.rst', 'U').read()
+long_description = open(os.path.join(BASE_PATH, 'README.rst'), 'U').read()
 distmeta = open(PYCP('distmeta.h')).read().strip().splitlines()
 distmeta = [item.split('\"')[1] for item in distmeta]
 version = distmeta[0].strip()


### PR DESCRIPTION
This PR fixes #110 :

```
$ pip3 install git+https://github.com/matusvalo/librabbitmq.git@pip_build
Collecting git+https://github.com/matusvalo/librabbitmq.git@pip_build
  Cloning https://github.com/matusvalo/librabbitmq.git (to pip_build) to /tmp/pip-nzel7l8l-build
Requirement already satisfied: amqp>=1.4.6 in ./envs/test35/lib/python3.5/site-packages (from librabbitmq==2.0.0)
Requirement already satisfied: six>=1.0.0 in ./envs/test35/lib/python3.5/site-packages (from librabbitmq==2.0.0)
Requirement already satisfied: vine>=1.1.3 in ./envs/test35/lib/python3.5/site-packages (from amqp>=1.4.6->librabbitmq==2.0.0)
Installing collected packages: librabbitmq
  Running setup.py install for librabbitmq ... done
Successfully installed librabbitmq-2.0.0
```