### PR TITLE
Fix manylinux1, exclude cp27-27mu (#146)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ rabbitmq-c: submodules
 
 
 rabbitmq-clean:
+	-(rm -rf $(RABBIT_DIR)/build || true)
 	-(cd $(RABBIT_DIR) && make clean || echo "warning... rabbitmq-clean failed")
 
 rabbitmq-distclean:

--- a/build-manylinux1-wheels.sh
+++ b/build-manylinux1-wheels.sh
@@ -5,29 +5,35 @@ set -e -x
 # Install system packages required by our library
 yum install -y cmake openssl-devel gcc automake
 
-# Ensure a fresh build of rabbitmq-c.
-(cd /workspace && make submodules)
-rm -rf /workspace/rabbitmq-c/build
-(cd /workspace && make rabbitmq-c)
-
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
+    # cp27-cp27mu builds fail with: undefined symbol: PyUnicodeUCS2_AsASCIIString
+    if [[ "${PYBIN}" == *"cp27-cp27mu"* ]]; then
+        continue
+    fi
+
+    # Ensure a fresh build of rabbitmq-c.
+    rm -rf /workspace/rabbitmq-c/build
     (cd /workspace && ${PYBIN}/python setup.py install)
     ${PYBIN}/pip wheel /workspace/ -w wheelhouse/
 done
 
 # Bundle external shared libraries into the wheels
-#ls wheelhouse/*
 for whl in wheelhouse/*linux*.whl; do
     auditwheel repair $whl -w /workspace/wheelhouse/
 done
 
 # Install packages and test
 for PYBIN in /opt/python/*/bin/; do
-    # vine 5.0.0a1 breaks python2
+    if [[ "${PYBIN}" == *"cp27-cp27mu"* ]]; then
+        continue
+    fi
+
+    # amqp 5.0.0a1 and vine 5.0.0a1 breaks python2
     # https://github.com/celery/vine/issues/34
-    if [[ "$PYBIN" == *"python/cp2"* ]]; then
+    if [[ "${PYBIN}" == *"python/cp2"* ]]; then
         ${PYBIN}/pip install --force-reinstall "vine==1.3.0"
+        ${PYBIN}/pip install --force-reinstall "amqp==2.5.2"
     fi
 
     ${PYBIN}/pip install librabbitmq -f /workspace/wheelhouse

--- a/setup.py
+++ b/setup.py
@@ -155,8 +155,9 @@ def create_builder():
                             return
 
                         os.chdir('build')
-                        if os.system(cmake + ' ..'):
-                            return
+                        if not os.path.isfile('Makefile'):
+                            if os.system(cmake + ' ..'):
+                                return
 
                         if os.system(make + ' rabbitmq rabbitmq-static'):
                             return


### PR DESCRIPTION
Thanks for merging my previous PR. Found an issue with cp27-cp27mu build. (It fails with: undefined symbol: PyUnicodeUCS2_AsASCIIString) so I'm excluding it for now.

Output of a travis build with the same changes (+ Maybe_Unicode memory leak fix): https://travis-ci.org/github/henryykt/librabbitmq/builds/667608140
