### PR TITLE
Fix manylinux1 cp27-cp27mu wheel

### DIFF
--- a/build-manylinux1-wheels.sh
+++ b/build-manylinux1-wheels.sh
@@ -7,36 +7,36 @@ yum install -y cmake openssl-devel gcc automake
 
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
-    # cp27-cp27mu builds fail with: undefined symbol: PyUnicodeUCS2_AsASCIIString
-    if [[ "${PYBIN}" == *"cp27-cp27mu"* ]]; then
-        continue
-    fi
-
     # Ensure a fresh build of rabbitmq-c.
-    rm -rf /workspace/rabbitmq-c/build
-    (cd /workspace && ${PYBIN}/python setup.py install)
-    ${PYBIN}/pip wheel /workspace/ -w wheelhouse/
+    (cd /workspace && PATH="${PYBIN}:${PATH}" make clean)
+    (cd /workspace && "${PYBIN}"/python setup.py install)
+    "${PYBIN}"/pip wheel /workspace/ -w wheelhouse/
 done
+
+# use a temporary directory to avoid picking up old wheels
+WHEELHOUSE=/workspace/wheelhouse
+TMP_WHEELHOUSE=$(mktemp -d -p "${WHEELHOUSE}")
 
 # Bundle external shared libraries into the wheels
 for whl in wheelhouse/*linux*.whl; do
-    auditwheel repair $whl -w /workspace/wheelhouse/
+    auditwheel repair "$whl" -w "${TMP_WHEELHOUSE}"
 done
 
 # Install packages and test
 for PYBIN in /opt/python/*/bin/; do
-    if [[ "${PYBIN}" == *"cp27-cp27mu"* ]]; then
-        continue
-    fi
+    PYVER=$(echo "${PYBIN}" | cut -d'/' -f 4)
 
     # amqp 5.0.0a1 and vine 5.0.0a1 breaks python2
     # https://github.com/celery/vine/issues/34
-    if [[ "${PYBIN}" == *"python/cp2"* ]]; then
-        ${PYBIN}/pip install --force-reinstall "vine==1.3.0"
-        ${PYBIN}/pip install --force-reinstall "amqp==2.5.2"
+    if [[ "${PYVER}" == *"cp2"* ]]; then
+        "${PYBIN}"/pip install --force-reinstall "vine==1.3.0"
+        "${PYBIN}"/pip install --force-reinstall "amqp==2.5.2"
     fi
 
-    ${PYBIN}/pip install librabbitmq -f /workspace/wheelhouse
-    ${PYBIN}/python -c "import librabbitmq"
+    "${PYBIN}"/pip install librabbitmq --no-index -f "${TMP_WHEELHOUSE}"/*-"${PYVER}"-*.whl
+    "${PYBIN}"/python -c "import librabbitmq"
     #(cd $HOME; ${PYBIN}/nosetests pymanylinuxdemo)
+    mv -f "${TMP_WHEELHOUSE}"/*-"${PYVER}"-*.whl ${WHEELHOUSE}
 done
+
+rmdir "${TMP_WHEELHOUSE}"


### PR DESCRIPTION
Finally found out what triggers the "undefined symbol: PyUnicodeUCS2_AsASCIIString" error.

The `${PYBIN}/pip install librabbitmq -f /workspace/wheelhouse` command passes the whole wheelhouse directory to pip and cause the cp27-cp27mu wheel picked up the wrong library.

I suspect it's due to both python2 wheels generating the same _librabbitmq.so, while python3 wheels generate library names that include version (e.g. _librabbitmq.cpython-38-x86_64-linux-gnu.so) 
