### PR TITLE
Fix to adapt to changes in python3.7+ C API

### DIFF
--- a/Modules/_librabbitmq/connection.h
+++ b/Modules/_librabbitmq/connection.h
@@ -49,7 +49,7 @@
 # elif defined(__GNUC__) && !defined(__GNUC_STDC_INLINE__)
 #  define _PYRMQ_INLINE extern __inline
 # else
-#  define _PYRMQ_INLINE __inline
+#  define _PYRMQ_INLINE extern __inline
 # endif
 #endif
 


### PR DESCRIPTION
This PR is related to #136 and #137
 
There were some changes in the C API, according to python documentation https://docs.python.org/3/whatsnew/3.8.html, namely "Some macros have been converted to static inline functions" and then followed by the list of affected functions, which includes Py_DECREF().

Changes proposed in the PR should fix the issues.
Tested in python 3.8.2 and 3.5.6