### PR TITLE
Simplify memory leak fix (avoid using amqp_pool_alloc)

### DIFF
--- a/Modules/_librabbitmq/connection.h
+++ b/Modules/_librabbitmq/connection.h
@@ -104,8 +104,6 @@ buffer_toMemoryView(char *buf, Py_ssize_t buf_len) {
             PySTRING_FROM_AMQBYTES(table->headers.entries[i].key),  \
             stmt);                                                  \
 
-_PYRMQ_INLINE PyObject* Maybe_Unicode(PyObject *);
-
 #if defined(__C99__) || defined(__GNUC__)
 #  define PyString_AS_AMQBYTES(s)                                   \
       (amqp_bytes_t){Py_SIZE(s), (void *)PyBytes_AS_STRING(s)}
@@ -121,14 +119,6 @@ PyString_AS_AMQBYTES(PyObject *s)
     return ret;
 }
 #endif
-
-_PYRMQ_INLINE PyObject*
-Maybe_Unicode(PyObject *s)
-{
-    if (PyUnicode_Check(s))
-        return PyUnicode_AsASCIIString(s);
-    return s;
-}
 
 #define PYRMQ_IS_TIMEOUT(t)   (t > 0.0)
 #define PYRMQ_IS_NONBLOCK(t)  (t == -1)
@@ -171,21 +161,6 @@ typedef struct {
 
     PyObject *weakreflist;
 } PyRabbitMQ_Connection;
-
-// Keep track of PyObject references with increased reference count.
-// Entries are stored in the channel pool.
-#define PYOBJECT_POOL_MAX 100
-typedef struct pyobject_pool_t_ {
-    int num_entries;
-    PyObject **entries;
-    amqp_pool_t *pool;
-    struct pyobject_pool_t_ *next;
-} pyobject_pool_t;
-
-int
-PyDict_to_basic_properties(PyObject *, amqp_basic_properties_t *,
-                           amqp_connection_state_t, amqp_pool_t *,
-                           pyobject_pool_t *);
 
 /* Connection method sigs */
 static PyRabbitMQ_Connection*


### PR DESCRIPTION
This simplifies the memory leak fix introduced in #145.

- use pyobject_array_t only (removed pyobject_pool_t)
- avoid use of amqp_pool_alloc. (cannot use it to keep track of variables that need ref count decreased. The memory might be cleaned up already if client gets disconnect while sending a message.)
