### PR TITLE
Add connect_timeout parameter to Connection

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,12 @@
 .. contents::
     :local:
 
+Next Release
+============
+
+- Add support for ``Connection.connect_timeout`` parameter
+
+
 .. _version-2.0.0:
 
 2.0.0

--- a/Modules/_librabbitmq/connection.h
+++ b/Modules/_librabbitmq/connection.h
@@ -151,6 +151,7 @@ typedef struct {
     int frame_max;
     int channel_max;
     int heartbeat;
+    int connect_timeout;
 
     int sockfd;
     int connected;
@@ -267,6 +268,8 @@ static PyMemberDef PyRabbitMQ_ConnectionType_members[] = {
         offsetof(PyRabbitMQ_Connection, frame_max), READONLY, NULL},
     {"callbacks", T_OBJECT_EX,
         offsetof(PyRabbitMQ_Connection, callbacks), READONLY, NULL},
+    {"connect_timeout", T_INT,
+        offsetof(PyRabbitMQ_Connection, connect_timeout), READONLY, NULL},
     {NULL, 0, 0, 0, NULL}  /* Sentinel */
 };
 

--- a/librabbitmq/__init__.py
+++ b/librabbitmq/__init__.py
@@ -191,7 +191,7 @@ class Connection(_librabbitmq.Connection):
     def __init__(self, host='localhost', userid='guest', password='guest',
                  virtual_host='/', port=5672, channel_max=0xffff,
                  frame_max=131072, heartbeat=0, lazy=False,
-                 client_properties=None, **kwargs):
+                 client_properties=None, connect_timeout=None, **kwargs):
         if ':' in host:
             host, port = host.split(':')
         super(Connection, self).__init__(
@@ -199,6 +199,7 @@ class Connection(_librabbitmq.Connection):
             virtual_host=virtual_host, channel_max=channel_max,
             frame_max=frame_max, heartbeat=heartbeat,
             client_properties=client_properties,
+            connect_timeout=0 if connect_timeout is None else int(connect_timeout),
         )
         self.channels = {}
         self._used_channel_ids = array('H')


### PR DESCRIPTION
Add support for the `connect_timeout` parameter to the `Connection` class.
When provided, call the `amqp_socket_open_noblock` function with the `timeout` parameter.