### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ RABBIT_DIST=librabbitmq
 # Distribuition tools
 PYTHON=python
 
-all: build
+all: build manylinux2014
 
 add-submodules:
 	-git submodule add -b v0.8.0 https://github.com/alanxz/rabbitmq-c.git
@@ -57,8 +57,16 @@ $(RABBIT_TARGET):
 
 dist: rabbitmq-c $(RABBIT_TARGET)
 
-manylinux1: dist
-	 docker run --rm -v `pwd`:/workspace:z quay.io/pypa/manylinux1_x86_64  /workspace/build-manylinux1-wheels.sh
+manylinux2014: manylinux2014_x86_64 manylinux2014_aarch64
+
+manylinux2014_x86_64: dist
+	 docker run --rm -v `pwd`:/workspace:z quay.io/pypa/manylinux2014_x86_64  /workspace/build-manylinux1-wheels.sh
+
+qemu-user-static:
+	docker run --rm --privileged hypriot/qemu-register
+
+manylinux2014_aarch64: qemu-user-static
+	docker run --rm -v `pwd`:/workspace:z quay.io/pypa/manylinux2014_aarch64  /workspace/build-manylinux1-wheels.sh
 
 rebuild:
 	$(PYTHON) setup.py build

--- a/build-manylinux1-wheels.sh
+++ b/build-manylinux1-wheels.sh
@@ -6,7 +6,7 @@ set -e -x
 yum install -y cmake openssl-devel gcc automake
 
 # Compile wheels
-for PYBIN in /opt/python/*/bin; do
+for PYBIN in /opt/python/cp*/bin; do
     # Ensure a fresh build of rabbitmq-c.
     (cd /workspace && PATH="${PYBIN}:${PATH}" make clean)
     (cd /workspace && "${PYBIN}"/python setup.py install)
@@ -23,7 +23,7 @@ for whl in wheelhouse/*linux*.whl; do
 done
 
 # Install packages and test
-for PYBIN in /opt/python/*/bin/; do
+for PYBIN in /opt/python/cp*/bin/; do
     PYVER=$(echo "${PYBIN}" | cut -d'/' -f 4)
 
     # amqp 5.0.0a1 and vine 5.0.0a1 breaks python2


### PR DESCRIPTION
Add linux aarch64 wheel build support.

Related to https://github.com/celery/librabbitmq/issues/163