### PR TITLE
Fix casting from PyObject* to int for PyRabbitMQ_ConnectionType_init

### DIFF
--- a/Modules/_librabbitmq/connection.c
+++ b/Modules/_librabbitmq/connection.c
@@ -1081,7 +1081,8 @@ PyRabbitMQ_ConnectionType_init(PyRabbitMQ_Connection *self,
     self->virtual_host = PyMem_Malloc(strlen(virtual_host) + 1);
 
     if (self->hostname == NULL || self->userid == NULL || self->password == NULL || self->virtual_host == NULL) {
-        return PyErr_NoMemory();
+        PyErr_NoMemory();
+        return 0;
     }
 
     strcpy(self->hostname, hostname);


### PR DESCRIPTION
Fix compile error:
```text
/build/python-librabbitmq/src/librabbitmq-2.0.0/Modules/_librabbitmq/connection.c: In function ‘PyRabbitMQ_ConnectionType_init’:
/build/python-librabbitmq/src/librabbitmq-2.0.0/Modules/_librabbitmq/connection.c:1003:16: error: returning ‘PyObject *’ {aka ‘struct _object *’} from a function with return type ‘int’ makes integer from pointer without a cast [-Wint-conversion]
 1003 |         return PyErr_NoMemory();
      |                ^~~~~~~~~~~~~~~~
```
This won't cause return value changes as PyErr_NoMemory always returns NULL.