### PR TITLE
Add missing include

### DIFF
--- a/Modules/_librabbitmq/connection.c
+++ b/Modules/_librabbitmq/connection.c
@@ -7,10 +7,10 @@
 
 #include <amqp.h>
 #include <amqp_tcp_socket.h>
+#include <amqp_socket.h>
 
 #include "connection.h"
 #include "distmeta.h"
-#include "_amqstate.h"
 
 #define PYRABBITMQ_CONNECTION_ERROR 0x10
 #define PYRABBITMQ_CHANNEL_ERROR 0x20


### PR DESCRIPTION
Fixes error:
```text
/build/python-librabbitmq/src/librabbitmq-2.0.0/Modules/_librabbitmq/connection.c: In function ‘PyRabbitMQ_recv’:
/build/python-librabbitmq/src/librabbitmq-2.0.0/Modules/_librabbitmq/connection.c:1359:13: error: implicit declaration of function ‘amqp_simple_wait_frame_on_channel’; did you mean ‘amqp_simple_wait_frame_noblock’? [-Wimplicit-function-declaration]
 1359 |             amqp_simple_wait_frame_on_channel(conn, cur_channel, &frame);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |             amqp_simple_wait_frame_noblock
```