### PR TITLE
file mode 'U' was deprecated in Python 3.3 and removed in Python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,12 +192,8 @@ def find_cmake():
     return ""
 
 
-if sys.version_info[0] < 3:
-    with open(os.path.join(BASE_PATH, 'README.rst'), 'U') as f:
-        long_description = f.read()
-else:
-    with open(os.path.join(BASE_PATH, 'README.rst')) as f:
-        long_description = f.read()
+with open(os.path.join(BASE_PATH, 'README.rst')) as f:
+    long_description = f.read()
 
 distmeta = open(PYCP('distmeta.h')).read().strip().splitlines()
 distmeta = [item.split('\"')[1] for item in distmeta]


### PR DESCRIPTION
The Python file mode 'U' was deprecated in Python 3.3 and completely removed in Python 3.11.
* https://docs.python.org/3.11/whatsnew/3.11.html#porting-to-python-3-11

Python 2 died 2,084 days ago on 1/1/2020 so perhaps it is time to drop code that supports it.