### PR TITLE
pre-commit: Upgrade hooks from v5 to v6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       # - id: check-builtin-literals
       # - id: check-executables-have-shebangs


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v5.0.0 -> v6.0.0
```
* https://github.com/pre-commit/pre-commit-hooks