### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       # - id: check-builtin-literals
       # - id: check-executables-have-shebangs
@@ -17,3 +17,12 @@ repos:
       - id: end-of-file-fixer
       # - id: mixed-line-ending
       # - id: trailing-whitespace
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=declatory
+        additional_dependencies:
+          - tomli

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 RABBIT_DIR=rabbitmq-c
 RABBIT_DIST=librabbitmq
 
-# Distribuition tools
+# Distribution tools
 PYTHON=python
 
 all: build manylinux2014


### PR DESCRIPTION
https://pypi.org/project/codespell

Ignore a typo in the license, which was fixed in the official MPL.
> LICENSE-MPL-RabbitMQ:330: declatory ==> declaratory